### PR TITLE
refactor: types

### DIFF
--- a/packages/slate-plugins/src/common/types/PluginOptions.types.ts
+++ b/packages/slate-plugins/src/common/types/PluginOptions.types.ts
@@ -38,15 +38,29 @@ export interface RenderElementPropsWithAttributes extends RenderElementProps {
   element: ElementWithAttributes;
 }
 
-export interface NodeToPropsOptions
-  extends RenderElementPropsWithAttributes,
-    RootProps<RenderNodePropsOptions> {}
+export interface ElementNode<T = Element> {
+  element: T;
+}
 
-export interface NodeToProps<T> {
+export interface NodeToPropsOptions<
+  ElementType = Element,
+  RootPropsType = RenderNodePropsOptions
+>
+  extends Omit<RenderElementPropsWithAttributes, 'element'>,
+    RootProps<RootPropsType> {
+  element: ElementType;
+}
+
+export interface NodeToProps<
+  ElementType = Element & { [key: string]: any },
+  RootPropsType = RenderNodePropsOptions & { [key: string]: any }
+> {
   /**
    * Function to evaluate a node and return props
    */
-  nodeToProps?: (options: T) => HtmlAttributes;
+  nodeToProps?: (
+    options: NodeToPropsOptions<ElementType, RootPropsType>
+  ) => HtmlAttributes;
 }
 
 export type HtmlAttributes = { [key: string]: any } | undefined;

--- a/packages/slate-plugins/src/common/utils/getRenderElement.tsx
+++ b/packages/slate-plugins/src/common/utils/getRenderElement.tsx
@@ -2,14 +2,13 @@ import * as React from 'react';
 import pickBy from 'lodash/pickBy';
 import {
   NodeToProps,
-  NodeToPropsOptions,
   RenderElementPropsWithAttributes,
   RenderNodeOptions,
 } from '../types/PluginOptions.types';
 
 export interface GetRenderElementOptions
   extends Required<RenderNodeOptions>,
-    NodeToProps<NodeToPropsOptions> {}
+    NodeToProps<any, any> {}
 
 /**
  * Get a `renderElement` handler for a single type.

--- a/packages/slate-plugins/src/elements/link/types.ts
+++ b/packages/slate-plugins/src/elements/link/types.ts
@@ -7,8 +7,6 @@ import {
   ElementWithAttributes,
   HtmlAttributesProps,
   NodeToProps,
-  NodeToPropsOptions,
-  RenderElementPropsWithAttributes,
   RenderNodeOptions,
   RenderNodePropsOptions,
   RootProps,
@@ -24,11 +22,6 @@ export interface LinkNodeData {
 }
 // Element node
 export interface LinkNode extends ElementWithAttributes, LinkNodeData {}
-
-export type LinkNodeToPropsOptions = NodeToPropsOptions &
-  RootProps<LinkRenderElementPropsOptions> & {
-    element: LinkNode;
-  };
 
 // renderElement options given as props
 export interface LinkRenderElementPropsOptions {
@@ -55,7 +48,7 @@ export type LinkKeyOption = 'link';
 // Plugin options
 export type LinkPluginOptionsValues = RenderNodeOptions &
   RootProps<LinkRenderElementPropsOptions> &
-  NodeToProps<LinkNodeToPropsOptions> &
+  NodeToProps<LinkNode, LinkRenderElementPropsOptions> &
   Deserialize & {
     /**
      * Callback to validate an url.
@@ -70,7 +63,9 @@ export type LinkPluginOptions<
 // renderElement options
 export type LinkRenderElementOptionsKeys = LinkPluginOptionsKeys;
 export interface LinkRenderElementOptions
-  extends LinkPluginOptions<'type' | 'component' | 'rootProps'> {}
+  extends LinkPluginOptions<
+    'type' | 'component' | 'rootProps' | 'nodeToProps'
+  > {}
 
 // deserialize options
 export interface LinkDeserializeOptions


### PR DESCRIPTION
@danlunde added generic type:

```typescript
export interface NodeToProps<
  ElementType = Element & { [key: string]: any },
  RootPropsType = RenderNodePropsOptions & { [key: string]: any }
> {
  /**
   * Function to evaluate a node and return props
   */
  nodeToProps?: (
    options: NodeToPropsOptions<ElementType, RootPropsType>
  ) => HtmlAttributes;
}
``` 

There was still the ts error in `renderElementLink` so I've just put the generics to `any`. It doesn't bring a lot of value to have strict types there.

```
export interface GetRenderElementOptions
  extends Required<RenderNodeOptions>,
    NodeToProps<any, any> {}
```